### PR TITLE
Reduce lift speed; make separate left/right configs for the arm.

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -173,7 +173,7 @@ public final class Constants {
     public static final double LIFT_HEIGHT_2 = 2;
     public static final double LIFT_HEIGHT_3 = 3;
 
-    public static final double LIFT_SPEED = 1.0;
+    public static final double LIFT_SPEED = 0.15; // 1.0; // Temporarily apply a slower speed to observe the lift before damage is incurred
     public static final double CORAL_INTAKE_SPEED = 0.3;
   }
 


### PR DESCRIPTION
The arm lift axle twisted today due to the two brushless NEO motors spinning full speed in opposing directions.  This is an expensive repair, and it would not have been necessary if we had done things right to begin with.  I share much of the blame for this; we discussed the possibility of this happening but effected no code changes.

This pull request does things the right way, making four separate config objects where once there were just two.  The only difference between the left and right configurations is the follow() command.

None of this is tested.  The lift speed is deliberately reduced so that the behavior can be carefully observed while testing; I recommend keeping the twisted axle in place for this so that no further axles are damaged should my change not work.